### PR TITLE
Added study guide sections to revision card proto

### DIFF
--- a/org/oppia/proto/v1/structure/revision_card.proto
+++ b/org/oppia/proto/v1/structure/revision_card.proto
@@ -27,21 +27,19 @@ message RevisionCardDto {
   // The localizable title of the revision card.
   SubtitledTextDto title = 3;
 
-  // This represents the legacy single-block representation of a revision card. It is no longer
-  // populated for revision cards sourced as study guides; 'sections' should be used instead. It is
-  // retained only for backward compatibility with older clients.
-  SubtitledTextDto content = 4;
+  // Reserved for the old single-block revision card content field.
+  reserved 4;
+  reserved "content";
+
+  // The ordered list of study guide sections that make up this revision card. Each section is a
+  // heading and content pair.
+  repeated StudyGuideSectionDto sections = 7;
 
   // The default localized text, images, and voiceovers of this revision card.
   ContentLocalizationDto default_localization = 5;
 
   // The version of the revision card's contents.
   uint32 content_version = 6;
-
-  // The ordered list of study guide sections that make up this revision card. Each section is a
-  // heading and content pair. This is the current representation of revision card content and
-  // supersedes the single 'content' field above.
-  repeated StudyGuideSectionDto sections = 7;
 }
 
 // Represents a single section of a study guide: a heading paired with its content. Study guides are

--- a/org/oppia/proto/v1/structure/revision_card.proto
+++ b/org/oppia/proto/v1/structure/revision_card.proto
@@ -27,7 +27,9 @@ message RevisionCardDto {
   // The localizable title of the revision card.
   SubtitledTextDto title = 3;
 
-  // The main content of this revision card.
+  // This represents the legacy single-block representation of a revision card. It is no longer
+  // populated for revision cards sourced as study guides; 'sections' should be used instead. It is
+  // retained only for backward compatibility with older clients.
   SubtitledTextDto content = 4;
 
   // The default localized text, images, and voiceovers of this revision card.
@@ -35,6 +37,24 @@ message RevisionCardDto {
 
   // The version of the revision card's contents.
   uint32 content_version = 6;
+
+  // The ordered list of study guide sections that make up this revision card. Each section is a
+  // heading and content pair. This is the current representation of revision card content and
+  // supersedes the single 'content' field above.
+  repeated StudyGuideSectionDto sections = 7;
+}
+
+// Represents a single section of a study guide: a heading paired with its content. Study guides are
+// the sectioned representation of revision cards, allowing content to be split into smaller,
+// easier-to-read and easier-to-translate parts.
+message StudyGuideSectionDto {
+  option (org.oppia.proto.v1.versions.structure_proto_version_type) = REVISION_CARD_PROTO_VERSION;
+
+  // The localizable heading shown at the top of the section.
+  SubtitledTextDto heading = 1;
+
+  // The localizable main content shown under the heading.
+  SubtitledTextDto content = 2;
 }
 
 // Represents a localized language pack corresponding to both a single revision card and a single


### PR DESCRIPTION
## Explanation
This PR adds support for structured Study Guide sections in `RevisionCardDto`.

Right now, revision cards mainly store their content in one single `content` field. But the new Study Guide format is different because it has multiple sections, and each section has its own heading and content. So this PR adds a new `sections` field to store that structure properly.

The old `content` field is not removed. It is still kept so that older clients and the existing revision-card flow can continue to work.

This is the proto API change needed for oppia/oppia-android#6105.

## Tests

- `bazel build //org/oppia/proto/v1/structure:structure_proto`
- `bazel test //org/oppia/proto/v1/structure:structure_proto_lint_test`